### PR TITLE
Add missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The demonstration features a simulation of a robotic arm equipped with a gripper
 - Install the packages required by this project:
 ```bash
 rosdep install --from-paths ros2_ws/src --ignore-src -r -y
-sudo apt install ros-jazzy-moveit-configs-utils ros-jazzy-moveit-resources-panda-moveit-config
 ```
 - Install `git-lfs` for pulling binary files:
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ The demonstration features a simulation of a robotic arm equipped with a gripper
 ## Prerequisites
 - Install [ROS2](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
 - Install all ROS2 packages [required by O3DE](https://docs.o3de.org/docs/user-guide/interactivity/robotics/project-configuration/)
-- Install the MoveIt package:
+- Install the packages required by this project:
 ```bash
-sudo apt install "ros-jazzy-moveit*"
+rosdep install --from-paths ros2_ws/src --ignore-src -r -y
+sudo apt install ros-jazzy-moveit-configs-utils ros-jazzy-moveit-resources-panda-moveit-config
 ```
 - Install `git-lfs` for pulling binary files:
 ```bash

--- a/ros2_ws/src/robotic_manipulation/package.xml
+++ b/ros2_ws/src/robotic_manipulation/package.xml
@@ -9,10 +9,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>moveit_ros_planning_interface</depend>
   <depend>rclcpp</depend>
   <depend>gazebo_msgs</depend>
   <depend>vision_msgs</depend>
+  <depend>moveit_ros_planning_interface</depend>
+  <depend>moveit_planners</depend>
+  <depend>moveit_simple_controller_manager</depend>
+  <depend>ackermann_msgs</depend>
+  <depend>control_toolbox</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rai_interfaces</depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/ros2_ws/src/robotic_manipulation/package.xml
+++ b/ros2_ws/src/robotic_manipulation/package.xml
@@ -15,6 +15,8 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_planners</depend>
   <depend>moveit_simple_controller_manager</depend>
+  <depend>moveit_configs_utils</depend>
+  <depend>moveit_resources_panda_moveit_config</depend>
   <depend>ackermann_msgs</depend>
   <depend>control_toolbox</depend>
   <depend>rosbag2_cpp</depend>


### PR DESCRIPTION
Some dependencies were not listed in the robotic_manipulation package, which made running the demo impossible on a fresh ROS2 install. This PR adds them to the package.xml file so they can be installed using rosdep install.