### PR TITLE
Refactor the robotic manipulation package

### DIFF
--- a/ros2_ws/src/robotic_manipulation/.clang-format
+++ b/ros2_ws/src/robotic_manipulation/.clang-format
@@ -1,0 +1,18 @@
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterEnum: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false

--- a/ros2_ws/src/robotic_manipulation/CMakeLists.txt
+++ b/ros2_ws/src/robotic_manipulation/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(vision_msgs REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(rai_interfaces REQUIRED)
 
-add_executable(robotic_manipulation src/robotic_manipulation.cpp src/arm_controller.cpp src/state_controller.cpp)
+add_executable(robotic_manipulation src/robotic_manipulation.cpp src/arm_controller.cpp src/rai_manipulation_interface_node.cpp)
 target_include_directories(robotic_manipulation PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/ros2_ws/src/robotic_manipulation/CMakeLists.txt
+++ b/ros2_ws/src/robotic_manipulation/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(robotic_manipulation src/robotic_manipulation.cpp src/arm_control
 target_include_directories(robotic_manipulation PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_compile_features(robotic_manipulation PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_compile_features(robotic_manipulation PUBLIC c_std_99 cxx_std_20)  # Require C99 and C++20
 ament_target_dependencies(
   robotic_manipulation
   "moveit_ros_planning_interface"

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
@@ -42,6 +42,16 @@ public:
   void SetReferenceFrame(std::string const &frame);
 
 private:
+  // The joint values for the gripper to be open and closed.
+  static double constexpr OpenGripperJointValue = 0.038;
+  static double constexpr ClosedGripperJointValue = 0.002;
+
+  // The base orientation of the end effector resulting in the gripper pointing
+  // straight down.
+  static double constexpr EndEffectorBaseRoll = 0.0;
+  static double constexpr EndEffectorBasePitch = std::numbers::pi;
+  static double constexpr EndEffectorBaseYaw = 45.0 * std::numbers::pi / 180.0;
+
   void WaitForClockMessage();
 
   std::shared_ptr<moveit::planning_interface::MoveGroupInterface> m_pandaArm;

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
@@ -12,7 +12,8 @@ public:
   geometry_msgs::msg::Pose CalculatePose(double x, double y, double z,
                                          double r = 0.0);
 
-  bool MoveThroughWaypoints(const std::vector<geometry_msgs::msg::Pose>& waypoints);
+  bool
+  MoveThroughWaypoints(std::vector<geometry_msgs::msg::Pose> const &waypoints);
 
   void Open();
   void Close();

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
@@ -1,3 +1,18 @@
+/* Copyright (C) 2025 Robotec.AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <moveit/move_group_interface/move_group_interface.h>

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/arm_controller.h
@@ -17,18 +17,17 @@
 
 #include <moveit/move_group_interface/move_group_interface.h>
 
-class ArmController {
+class ArmController
+{
 public:
   ArmController() = default;
   ~ArmController();
 
   void Initialize();
 
-  geometry_msgs::msg::Pose CalculatePose(double x, double y, double z,
-                                         double r = 0.0);
+  geometry_msgs::msg::Pose CalculatePose(double x, double y, double z, double r = 0.0);
 
-  bool
-  MoveThroughWaypoints(std::vector<geometry_msgs::msg::Pose> const &waypoints);
+  bool MoveThroughWaypoints(std::vector<geometry_msgs::msg::Pose> const & waypoints);
 
   void Open();
   void Close();
@@ -37,9 +36,9 @@ public:
   bool GetGripper();
 
   std::vector<double> CaptureJointValues();
-  bool SetJointValues(std::vector<double> const &jointValues);
+  bool SetJointValues(std::vector<double> const & jointValues);
 
-  void SetReferenceFrame(std::string const &frame);
+  void SetReferenceFrame(std::string const & frame);
 
 private:
   // The joint values for the gripper to be open and closed.

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/rai_manipulation_interface_node.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/rai_manipulation_interface_node.h
@@ -15,22 +15,22 @@
 
 #pragma once
 
-#include "robotic_manipulation/arm_controller.h"
-
-#include "rai_interfaces/srv/manipulator_move_to.hpp"
 #include <std_srvs/srv/trigger.hpp>
 
-class RaiManipulationInterfaceNode {
+#include "rai_interfaces/srv/manipulator_move_to.hpp"
+#include "robotic_manipulation/arm_controller.h"
+
+class RaiManipulationInterfaceNode
+{
 public:
   RaiManipulationInterfaceNode();
 
-  void Initialize(ArmController &arm);
+  void Initialize(ArmController & arm);
   void Spin();
 
 private:
   rclcpp::Node::SharedPtr m_node;
-  rclcpp::Service<rai_interfaces::srv::ManipulatorMoveTo>::SharedPtr
-      m_moveToService;
+  rclcpp::Service<rai_interfaces::srv::ManipulatorMoveTo>::SharedPtr m_moveToService;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr m_resetService;
 
   rclcpp::executors::SingleThreadedExecutor m_executor;

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/rai_manipulation_interface_node.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/rai_manipulation_interface_node.h
@@ -17,10 +17,10 @@
 
 #include "robotic_manipulation/arm_controller.h"
 
-class StateController {
+class RaiManipulationInterfaceNode {
 public:
-  StateController();
-  ~StateController();
+  RaiManipulationInterfaceNode();
+  ~RaiManipulationInterfaceNode();
 
   void Begin(ArmController &arm);
 

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/rai_manipulation_interface_node.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/rai_manipulation_interface_node.h
@@ -17,16 +17,23 @@
 
 #include "robotic_manipulation/arm_controller.h"
 
+#include "rai_interfaces/srv/manipulator_move_to.hpp"
+#include <std_srvs/srv/trigger.hpp>
+
 class RaiManipulationInterfaceNode {
 public:
   RaiManipulationInterfaceNode();
-  ~RaiManipulationInterfaceNode();
 
-  void Begin(ArmController &arm);
+  void Initialize(ArmController &arm);
+  void Spin();
 
 private:
   rclcpp::Node::SharedPtr m_node;
+  rclcpp::Service<rai_interfaces::srv::ManipulatorMoveTo>::SharedPtr
+      m_moveToService;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr m_resetService;
+
   rclcpp::executors::SingleThreadedExecutor m_executor;
-  std::thread m_spinner;
+
   std::vector<double> m_startingPose;
 };

--- a/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/state_controller.h
+++ b/ros2_ws/src/robotic_manipulation/include/robotic_manipulation/state_controller.h
@@ -1,3 +1,18 @@
+/* Copyright (C) 2025 Robotec.AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include "robotic_manipulation/arm_controller.h"

--- a/ros2_ws/src/robotic_manipulation/package.xml
+++ b/ros2_ws/src/robotic_manipulation/package.xml
@@ -3,9 +3,9 @@
 <package format="3">
   <name>robotic_manipulation</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>A package providing services for robotic manipulation using RAI.</description>
   <maintainer email="kacper.dabrowski@robotec.ai">kdabrowski</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
@@ -44,33 +44,39 @@ geometry_msgs::msg::Pose ArmController::CalculatePose(double x, double y,
   return pose;
 }
 
-bool ArmController::MoveThroughWaypoints(const std::vector<geometry_msgs::msg::Pose>& waypoints) {
+bool ArmController::MoveThroughWaypoints(
+    std::vector<geometry_msgs::msg::Pose> const &waypoints) {
   auto logger = m_node->get_logger();
 
-  const int NumTries = 10;
+  int const NumTries = 10;
   for (int i = 0; i < NumTries; i++) {
     moveit_msgs::msg::RobotTrajectory trajectory;
     if (m_pandaArm->computeCartesianPath(waypoints, 0.01, 0.0, trajectory) ==
         -1) {
       RCLCPP_ERROR(logger,
-                    "MoveThroughWaypoints: Failed to compute Cartesian path");
+                   "MoveThroughWaypoints: Failed to compute Cartesian path");
       continue;
     }
 
-    if (m_pandaArm->execute(trajectory) == moveit::core::MoveItErrorCode::SUCCESS) {
+    if (m_pandaArm->execute(trajectory) ==
+        moveit::core::MoveItErrorCode::SUCCESS) {
       return true;
     }
-    RCLCPP_ERROR(logger, "MoveThroughWaypoints: Failed to execute trajectory, trying again...");
+    RCLCPP_ERROR(logger, "MoveThroughWaypoints: Failed to execute "
+                         "trajectory, trying again...");
   }
 
-  RCLCPP_ERROR(logger, "MoveThroughWaypoints: Failed to execute trajectory after %d tries", NumTries);
+  RCLCPP_ERROR(
+      logger,
+      "MoveThroughWaypoints: Failed to execute trajectory after %d tries",
+      NumTries);
   return false;
 }
 
 void ArmController::Open() {
   gripper.store(true);
- // m_hand->setNamedTarget("open");
-   m_hand->setJointValueTarget("panda_finger_joint1", 0.038);
+  // m_hand->setNamedTarget("open");
+  m_hand->setJointValueTarget("panda_finger_joint1", 0.038);
   while (m_hand->move() != moveit::core::MoveItErrorCode::SUCCESS) {
     RCLCPP_ERROR(m_node->get_logger(), "Failed to open hand");
   }
@@ -120,9 +126,8 @@ void ArmController::WaitForClockMessage() {
   auto qos = rclcpp::QoS(rclcpp::KeepLast(1));
   qos.best_effort();
   auto subscription = m_node->create_subscription<rosgraph_msgs::msg::Clock>(
-      "/clock", qos, [&] (rosgraph_msgs::msg::Clock::SharedPtr) {
-        clock_received = true;
-      });
+      "/clock", qos,
+      [&](rosgraph_msgs::msg::Clock::SharedPtr) { clock_received = true; });
   while (!clock_received) {
     rclcpp::spin_some(m_node);
   }

--- a/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
@@ -17,6 +17,18 @@
 
 #include <rosgraph_msgs/msg/clock.hpp>
 
+#include <numbers>
+
+// The joint values for the gripper to be open and closed.
+double const OpenGripperJointValue = 0.038;
+double const ClosedGripperJointValue = 0.002;
+
+// The base orientation of the end effector resulting in the gripper pointing
+// straight down.
+double const EndEffectorBaseRoll = 0.0;
+double const EndEffectorBasePitch = std::numbers::pi;
+double const EndEffectorBaseYaw = tf2Radians(45.0);
+
 void ArmController::Initialize() {
   m_node = rclcpp::Node::make_shared("arm_controller");
   m_node->set_parameter(rclcpp::Parameter("use_sim_time", true));
@@ -50,7 +62,8 @@ geometry_msgs::msg::Pose ArmController::CalculatePose(double x, double y,
   pose.position.z = z;
 
   auto quat = tf2::Quaternion();
-  quat.setEuler(0.0, M_PI, tf2Radians(45.0) + r);
+  quat.setEuler(EndEffectorBaseRoll, EndEffectorBasePitch,
+                EndEffectorBaseYaw + r);
   pose.orientation.x = quat.x();
   pose.orientation.y = quat.y();
   pose.orientation.z = quat.z();
@@ -90,8 +103,7 @@ bool ArmController::MoveThroughWaypoints(
 
 void ArmController::Open() {
   gripper.store(true);
-  // m_hand->setNamedTarget("open");
-  m_hand->setJointValueTarget("panda_finger_joint1", 0.038);
+  m_hand->setJointValueTarget("panda_finger_joint1", OpenGripperJointValue);
   while (m_hand->move() != moveit::core::MoveItErrorCode::SUCCESS) {
     RCLCPP_ERROR(m_node->get_logger(), "Failed to open hand");
   }
@@ -99,8 +111,7 @@ void ArmController::Open() {
 
 void ArmController::Close() {
   gripper.store(false);
-  m_hand->setJointValueTarget("panda_finger_joint1", 0.002);
-  // m_hand->setNamedTarget("close");
+  m_hand->setJointValueTarget("panda_finger_joint1", ClosedGripperJointValue);
   while (m_hand->move() != moveit::core::MoveItErrorCode::SUCCESS) {
     RCLCPP_ERROR(m_node->get_logger(), "Failed to close hand");
   }
@@ -112,9 +123,12 @@ std::vector<double> ArmController::GetEffectorPose() {
                                   pose.orientation.z, pose.orientation.w);
   tf2::Matrix3x3 m(rotation);
   m.getRPY(pose.orientation.x, pose.orientation.y, pose.orientation.z, 0);
-  return {pose.position.x,           pose.position.y,
-          pose.position.z,           pose.orientation.x,
-          pose.orientation.y - M_PI, pose.orientation.z - tf2Radians(135.0)};
+  return {pose.position.x,
+          pose.position.y,
+          pose.position.z,
+          pose.orientation.x,
+          pose.orientation.y - EndEffectorBasePitch,
+          pose.orientation.z - (tf2Radians(180.0) - EndEffectorBaseYaw)};
 };
 
 bool ArmController::GetGripper() { return gripper.load(); }

--- a/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
@@ -19,16 +19,6 @@
 
 #include <numbers>
 
-// The joint values for the gripper to be open and closed.
-double const OpenGripperJointValue = 0.038;
-double const ClosedGripperJointValue = 0.002;
-
-// The base orientation of the end effector resulting in the gripper pointing
-// straight down.
-double const EndEffectorBaseRoll = 0.0;
-double const EndEffectorBasePitch = std::numbers::pi;
-double const EndEffectorBaseYaw = tf2Radians(45.0);
-
 void ArmController::Initialize() {
   m_node = rclcpp::Node::make_shared("arm_controller");
   m_node->set_parameter(rclcpp::Parameter("use_sim_time", true));

--- a/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
@@ -15,11 +15,11 @@
 
 #include "robotic_manipulation/arm_controller.h"
 
+#include <numbers>
 #include <rosgraph_msgs/msg/clock.hpp>
 
-#include <numbers>
-
-void ArmController::Initialize() {
+void ArmController::Initialize()
+{
   m_node = rclcpp::Node::make_shared("arm_controller");
   m_node->set_parameter(rclcpp::Parameter("use_sim_time", true));
 
@@ -28,32 +28,31 @@ void ArmController::Initialize() {
   m_executor.add_node(m_node);
   m_spinner = std::thread([this]() { m_executor.spin(); });
 
-  m_pandaArm = std::make_shared<moveit::planning_interface::MoveGroupInterface>(
-      m_node, "panda_arm");
-  m_hand = std::make_shared<moveit::planning_interface::MoveGroupInterface>(
-      m_node, "hand");
+  m_pandaArm =
+    std::make_shared<moveit::planning_interface::MoveGroupInterface>(m_node, "panda_arm");
+  m_hand = std::make_shared<moveit::planning_interface::MoveGroupInterface>(m_node, "hand");
 
   m_pandaArm->setMaxVelocityScalingFactor(1.0);
   m_pandaArm->setMaxAccelerationScalingFactor(1.0);
 }
 
-ArmController::~ArmController() {
+ArmController::~ArmController()
+{
   m_executor.cancel();
   if (m_spinner.joinable()) {
     m_spinner.join();
   }
 }
 
-geometry_msgs::msg::Pose ArmController::CalculatePose(double x, double y,
-                                                      double z, double r) {
+geometry_msgs::msg::Pose ArmController::CalculatePose(double x, double y, double z, double r)
+{
   geometry_msgs::msg::Pose pose;
   pose.position.x = x;
   pose.position.y = y;
   pose.position.z = z;
 
   auto quat = tf2::Quaternion();
-  quat.setEuler(EndEffectorBaseRoll, EndEffectorBasePitch,
-                EndEffectorBaseYaw + r);
+  quat.setEuler(EndEffectorBaseRoll, EndEffectorBasePitch, EndEffectorBaseYaw + r);
   pose.orientation.x = quat.x();
   pose.orientation.y = quat.y();
   pose.orientation.z = quat.z();
@@ -62,36 +61,34 @@ geometry_msgs::msg::Pose ArmController::CalculatePose(double x, double y,
   return pose;
 }
 
-bool ArmController::MoveThroughWaypoints(
-    std::vector<geometry_msgs::msg::Pose> const &waypoints) {
+bool ArmController::MoveThroughWaypoints(std::vector<geometry_msgs::msg::Pose> const & waypoints)
+{
   auto logger = m_node->get_logger();
 
   int constexpr NumTries = 10;
   for (int i = 0; i < NumTries; i++) {
     moveit_msgs::msg::RobotTrajectory trajectory;
-    if (m_pandaArm->computeCartesianPath(waypoints, 0.01, 0.0, trajectory) ==
-        -1) {
-      RCLCPP_ERROR(logger,
-                   "MoveThroughWaypoints: Failed to compute Cartesian path");
+    if (m_pandaArm->computeCartesianPath(waypoints, 0.01, 0.0, trajectory) == -1) {
+      RCLCPP_ERROR(logger, "MoveThroughWaypoints: Failed to compute Cartesian path");
       continue;
     }
 
-    if (m_pandaArm->execute(trajectory) ==
-        moveit::core::MoveItErrorCode::SUCCESS) {
+    if (m_pandaArm->execute(trajectory) == moveit::core::MoveItErrorCode::SUCCESS) {
       return true;
     }
-    RCLCPP_ERROR(logger, "MoveThroughWaypoints: Failed to execute "
-                         "trajectory, trying again...");
+    RCLCPP_ERROR(
+      logger,
+      "MoveThroughWaypoints: Failed to execute "
+      "trajectory, trying again...");
   }
 
   RCLCPP_ERROR(
-      logger,
-      "MoveThroughWaypoints: Failed to execute trajectory after %d tries",
-      NumTries);
+    logger, "MoveThroughWaypoints: Failed to execute trajectory after %d tries", NumTries);
   return false;
 }
 
-void ArmController::Open() {
+void ArmController::Open()
+{
   gripper.store(true);
   m_hand->setJointValueTarget("panda_finger_joint1", OpenGripperJointValue);
   while (m_hand->move() != moveit::core::MoveItErrorCode::SUCCESS) {
@@ -99,7 +96,8 @@ void ArmController::Open() {
   }
 }
 
-void ArmController::Close() {
+void ArmController::Close()
+{
   gripper.store(false);
   m_hand->setJointValueTarget("panda_finger_joint1", ClosedGripperJointValue);
   while (m_hand->move() != moveit::core::MoveItErrorCode::SUCCESS) {
@@ -107,27 +105,31 @@ void ArmController::Close() {
   }
 }
 
-std::vector<double> ArmController::GetEffectorPose() {
+std::vector<double> ArmController::GetEffectorPose()
+{
   auto pose = m_pandaArm->getCurrentPose().pose;
-  auto rotation = tf2::Quaternion(pose.orientation.x, pose.orientation.y,
-                                  pose.orientation.z, pose.orientation.w);
+  auto rotation =
+    tf2::Quaternion(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
   tf2::Matrix3x3 m(rotation);
   m.getRPY(pose.orientation.x, pose.orientation.y, pose.orientation.z, 0);
-  return {pose.position.x,
-          pose.position.y,
-          pose.position.z,
-          pose.orientation.x,
-          pose.orientation.y - EndEffectorBasePitch,
-          pose.orientation.z - (tf2Radians(180.0) - EndEffectorBaseYaw)};
+  return {
+    pose.position.x,
+    pose.position.y,
+    pose.position.z,
+    pose.orientation.x,
+    pose.orientation.y - EndEffectorBasePitch,
+    pose.orientation.z - (tf2Radians(180.0) - EndEffectorBaseYaw)};
 };
 
 bool ArmController::GetGripper() { return gripper.load(); }
 
-std::vector<double> ArmController::CaptureJointValues() {
+std::vector<double> ArmController::CaptureJointValues()
+{
   return m_pandaArm->getCurrentJointValues();
 }
 
-bool ArmController::SetJointValues(std::vector<double> const &jointValues) {
+bool ArmController::SetJointValues(std::vector<double> const & jointValues)
+{
   m_pandaArm->setJointValueTarget(jointValues);
   if (m_pandaArm->move() != moveit::core::MoveItErrorCode::SUCCESS) {
     RCLCPP_ERROR(m_node->get_logger(), "Failed to set joint values");
@@ -136,17 +138,18 @@ bool ArmController::SetJointValues(std::vector<double> const &jointValues) {
   return true;
 }
 
-void ArmController::SetReferenceFrame(std::string const &frame) {
+void ArmController::SetReferenceFrame(std::string const & frame)
+{
   m_pandaArm->setPoseReferenceFrame(frame);
 }
 
-void ArmController::WaitForClockMessage() {
+void ArmController::WaitForClockMessage()
+{
   bool clockReceived = false;
   auto qos = rclcpp::QoS(rclcpp::KeepLast(1));
   qos.best_effort();
   auto subscription = m_node->create_subscription<rosgraph_msgs::msg::Clock>(
-      "/clock", qos,
-      [&](rosgraph_msgs::msg::Clock::SharedPtr) { clockReceived = true; });
+    "/clock", qos, [&](rosgraph_msgs::msg::Clock::SharedPtr) { clockReceived = true; });
   while (!clockReceived) {
     rclcpp::spin_some(m_node);
   }

--- a/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
@@ -1,3 +1,18 @@
+/* Copyright (C) 2025 Robotec.AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "robotic_manipulation/arm_controller.h"
 
 #include <rosgraph_msgs/msg/clock.hpp>

--- a/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
@@ -66,7 +66,7 @@ bool ArmController::MoveThroughWaypoints(
     std::vector<geometry_msgs::msg::Pose> const &waypoints) {
   auto logger = m_node->get_logger();
 
-  int const NumTries = 10;
+  int constexpr NumTries = 10;
   for (int i = 0; i < NumTries; i++) {
     moveit_msgs::msg::RobotTrajectory trajectory;
     if (m_pandaArm->computeCartesianPath(waypoints, 0.01, 0.0, trajectory) ==

--- a/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/arm_controller.cpp
@@ -151,13 +151,13 @@ void ArmController::SetReferenceFrame(std::string const &frame) {
 }
 
 void ArmController::WaitForClockMessage() {
-  bool clock_received = false;
+  bool clockReceived = false;
   auto qos = rclcpp::QoS(rclcpp::KeepLast(1));
   qos.best_effort();
   auto subscription = m_node->create_subscription<rosgraph_msgs::msg::Clock>(
       "/clock", qos,
-      [&](rosgraph_msgs::msg::Clock::SharedPtr) { clock_received = true; });
-  while (!clock_received) {
+      [&](rosgraph_msgs::msg::Clock::SharedPtr) { clockReceived = true; });
+  while (!clockReceived) {
     rclcpp::spin_some(m_node);
   }
   subscription.reset();

--- a/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
@@ -38,7 +38,8 @@ void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
               current_z, current_rx, current_ry, current_rz);
   RCLCPP_INFO(logger, "Current gripper state: %d", current_gripper_state);
 
-  m_moveToService = m_node->create_service<rai_interfaces::srv::ManipulatorMoveTo>(
+  m_moveToService = m_node->create_service<
+      rai_interfaces::srv::ManipulatorMoveTo>(
       "/manipulator_move_to",
       [&](std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Request> const
               request,
@@ -80,11 +81,18 @@ void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
           using std::max;
           auto current_pose = arm.GetEffectorPose();
           auto above_current = current_pose;
-          above_current[2] = min(0.4, max(above_current[2] + 0.1, 0.3));
+          auto calculate_z_above_target = [&](double target_z) {
+            double const minimum_z = 0.3;
+            double const maximum_z = 0.4;
+            double const z_offset = 0.1;
+
+            return min(maximum_z, max(target_z + z_offset, minimum_z));
+          };
+          above_current[2] = calculate_z_above_target(above_current[2]);
           auto above_target = request->target_pose.pose;
 
           above_target.position.z =
-              min(0.4, max(above_target.position.z + 0.1, 0.3));
+              calculate_z_above_target(above_target.position.z);
           if (!arm.MoveThroughWaypoints(
                   {arm.CalculatePose(above_current[0], above_current[1],
                                      above_current[2]),

--- a/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
@@ -13,26 +13,26 @@
  * limitations under the License.
  */
 
-#include "robotic_manipulation/state_controller.h"
+#include "robotic_manipulation/rai_manipulation_interface_node.h"
 
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
 #include "rai_interfaces/srv/manipulator_move_to.hpp"
 
-StateController::StateController()
+RaiManipulationInterfaceNode::RaiManipulationInterfaceNode()
     : m_node(rclcpp::Node::make_shared("state_controller")) {
   m_node->set_parameter(rclcpp::Parameter("use_sim_time", true));
 }
 
-StateController::~StateController() {
+RaiManipulationInterfaceNode::~RaiManipulationInterfaceNode() {
   m_executor.cancel();
   if (m_spinner.joinable()) {
     m_spinner.join();
   }
 }
 
-void StateController::Begin(ArmController &arm) {
+void RaiManipulationInterfaceNode::Begin(ArmController &arm) {
   auto logger = m_node->get_logger();
 
   auto current_pose = arm.GetEffectorPose();

--- a/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
@@ -25,18 +25,18 @@ RaiManipulationInterfaceNode::RaiManipulationInterfaceNode()
 void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
   auto logger = m_node->get_logger();
 
-  auto current_pose = arm.GetEffectorPose();
-  auto [current_x, current_y, current_z, current_rx, current_ry, current_rz] =
-      std::make_tuple(current_pose[0], current_pose[1], current_pose[2],
-                      current_pose[3], current_pose[4], current_pose[5]);
+  auto currentPose = arm.GetEffectorPose();
+  auto [currentX, currentY, currentZ, currentRX, currentRY, currentRZ] =
+      std::make_tuple(currentPose[0], currentPose[1], currentPose[2],
+                      currentPose[3], currentPose[4], currentPose[5]);
 
-  auto current_gripper_state = arm.GetGripper();
+  auto currentGripperState = arm.GetGripper();
 
   m_startingPose = arm.CaptureJointValues();
 
-  RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", current_x, current_y,
-              current_z, current_rx, current_ry, current_rz);
-  RCLCPP_INFO(logger, "Current gripper state: %d", current_gripper_state);
+  RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", currentX, currentY,
+              currentRZ, currentRX, currentRY, currentRZ);
+  RCLCPP_INFO(logger, "Current gripper state: %d", currentGripperState);
 
   m_moveToService = m_node->create_service<
       rai_interfaces::srv::ManipulatorMoveTo>(
@@ -54,14 +54,13 @@ void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
                     request->target_pose.header.frame_id.c_str());
 
         // Print current pose
-        auto current_pose = arm.GetEffectorPose();
-        auto [current_x, current_y, current_z, current_rx, current_ry,
-              current_rz] =
-            std::make_tuple(current_pose[0], current_pose[1], current_pose[2],
-                            current_pose[3], current_pose[4], current_pose[5]);
+        auto currentPose = arm.GetEffectorPose();
+        auto [currentX, currentY, currentZ, currentRX, currentRY, currentRZ] =
+            std::make_tuple(currentPose[0], currentPose[1], currentPose[2],
+                            currentPose[3], currentPose[4], currentPose[5]);
 
-        RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", current_x,
-                    current_y, current_z, current_rx, current_ry, current_rz);
+        RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", currentX,
+                    currentY, currentRZ, currentRX, currentRY, currentRZ);
         RCLCPP_INFO(logger, "Target pose: %f %f %f %f %f %f",
                     request->target_pose.pose.position.x,
                     request->target_pose.pose.position.y,
@@ -79,24 +78,24 @@ void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
         {
           using std::min;
           using std::max;
-          auto current_pose = arm.GetEffectorPose();
-          auto above_current = current_pose;
-          auto calculate_z_above_target = [&](double target_z) {
-            double const minimum_z = 0.3;
-            double const maximum_z = 0.4;
-            double const z_offset = 0.1;
+          auto currentPose = arm.GetEffectorPose();
+          auto aboveCurrent = currentPose;
+          auto calculateZAboveTarget = [&](double targetZ) {
+            double const MinimumZ = 0.3;
+            double const MaximumZ = 0.4;
+            double const ZOffset = 0.1;
 
-            return min(maximum_z, max(target_z + z_offset, minimum_z));
+            return min(MaximumZ, max(targetZ + ZOffset, MinimumZ));
           };
-          above_current[2] = calculate_z_above_target(above_current[2]);
-          auto above_target = request->target_pose.pose;
+          aboveCurrent[2] = calculateZAboveTarget(aboveCurrent[2]);
+          auto aboveTarget = request->target_pose.pose;
 
-          above_target.position.z =
-              calculate_z_above_target(above_target.position.z);
+          aboveTarget.position.z =
+              calculateZAboveTarget(aboveTarget.position.z);
           if (!arm.MoveThroughWaypoints(
-                  {arm.CalculatePose(above_current[0], above_current[1],
-                                     above_current[2]),
-                   above_target, request->target_pose.pose}))
+                  {arm.CalculatePose(aboveCurrent[0], aboveCurrent[1],
+                                     aboveCurrent[2]),
+                   aboveTarget, request->target_pose.pose}))
             return;
 
           if (request->final_gripper_state) {

--- a/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
@@ -18,112 +18,109 @@
 #include <std_msgs/msg/float32_multi_array.hpp>
 
 RaiManipulationInterfaceNode::RaiManipulationInterfaceNode()
-    : m_node(rclcpp::Node::make_shared("state_controller")) {
+: m_node(rclcpp::Node::make_shared("state_controller"))
+{
   m_node->set_parameter(rclcpp::Parameter("use_sim_time", true));
 }
 
-void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
+void RaiManipulationInterfaceNode::Initialize(ArmController & arm)
+{
   auto logger = m_node->get_logger();
 
   auto currentPose = arm.GetEffectorPose();
-  auto [currentX, currentY, currentZ, currentRX, currentRY, currentRZ] =
-      std::make_tuple(currentPose[0], currentPose[1], currentPose[2],
-                      currentPose[3], currentPose[4], currentPose[5]);
+  auto [currentX, currentY, currentZ, currentRX, currentRY, currentRZ] = std::make_tuple(
+    currentPose[0], currentPose[1], currentPose[2], currentPose[3], currentPose[4], currentPose[5]);
 
   auto currentGripperState = arm.GetGripper();
 
   m_startingPose = arm.CaptureJointValues();
 
-  RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", currentX, currentY,
-              currentRZ, currentRX, currentRY, currentRZ);
+  RCLCPP_INFO(
+    logger, "Current pose: %f %f %f %f %f %f", currentX, currentY, currentRZ, currentRX, currentRY,
+    currentRZ);
   RCLCPP_INFO(logger, "Current gripper state: %d", currentGripperState);
 
-  m_moveToService = m_node->create_service<
-      rai_interfaces::srv::ManipulatorMoveTo>(
-      "/manipulator_move_to",
-      [&](std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Request> const
-              request,
-          std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Response>
-              response) {
-        RCLCPP_INFO(logger, "Received move request");
+  m_moveToService = m_node->create_service<rai_interfaces::srv::ManipulatorMoveTo>(
+    "/manipulator_move_to",
+    [&](
+      std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Request> const request,
+      std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Response> response) {
+      RCLCPP_INFO(logger, "Received move request");
 
-        response->success = false;
+      response->success = false;
 
-        arm.SetReferenceFrame(request->target_pose.header.frame_id);
-        RCLCPP_INFO(logger, "Set reference frame to: %s",
-                    request->target_pose.header.frame_id.c_str());
+      arm.SetReferenceFrame(request->target_pose.header.frame_id);
+      RCLCPP_INFO(
+        logger, "Set reference frame to: %s", request->target_pose.header.frame_id.c_str());
 
-        // Print current pose
+      // Print current pose
+      auto currentPose = arm.GetEffectorPose();
+      auto [currentX, currentY, currentZ, currentRX, currentRY, currentRZ] = std::make_tuple(
+        currentPose[0], currentPose[1], currentPose[2], currentPose[3], currentPose[4],
+        currentPose[5]);
+
+      RCLCPP_INFO(
+        logger, "Current pose: %f %f %f %f %f %f", currentX, currentY, currentRZ, currentRX,
+        currentRY, currentRZ);
+      RCLCPP_INFO(
+        logger, "Target pose: %f %f %f %f %f %f", request->target_pose.pose.position.x,
+        request->target_pose.pose.position.y, request->target_pose.pose.position.z,
+        request->target_pose.pose.orientation.x, request->target_pose.pose.orientation.y,
+        request->target_pose.pose.orientation.z);
+
+      if (request->initial_gripper_state) {
+        arm.Open();
+      } else {
+        arm.Close();
+      }
+
+      {
+        using std::min;
+        using std::max;
         auto currentPose = arm.GetEffectorPose();
-        auto [currentX, currentY, currentZ, currentRX, currentRY, currentRZ] =
-            std::make_tuple(currentPose[0], currentPose[1], currentPose[2],
-                            currentPose[3], currentPose[4], currentPose[5]);
+        auto aboveCurrent = currentPose;
+        auto calculateZAboveTarget = [&](double targetZ) {
+          double constexpr MinimumZ = 0.3;
+          double constexpr MaximumZ = 0.4;
+          double constexpr ZOffset = 0.1;
 
-        RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", currentX,
-                    currentY, currentRZ, currentRX, currentRY, currentRZ);
-        RCLCPP_INFO(logger, "Target pose: %f %f %f %f %f %f",
-                    request->target_pose.pose.position.x,
-                    request->target_pose.pose.position.y,
-                    request->target_pose.pose.position.z,
-                    request->target_pose.pose.orientation.x,
-                    request->target_pose.pose.orientation.y,
-                    request->target_pose.pose.orientation.z);
+          return min(MaximumZ, max(targetZ + ZOffset, MinimumZ));
+        };
+        aboveCurrent[2] = calculateZAboveTarget(aboveCurrent[2]);
+        auto aboveTarget = request->target_pose.pose;
 
-        if (request->initial_gripper_state) {
+        aboveTarget.position.z = calculateZAboveTarget(aboveTarget.position.z);
+        if (!arm.MoveThroughWaypoints(
+              {arm.CalculatePose(aboveCurrent[0], aboveCurrent[1], aboveCurrent[2]), aboveTarget,
+               request->target_pose.pose}))
+          return;
+
+        if (request->final_gripper_state) {
           arm.Open();
         } else {
           arm.Close();
         }
+      }
 
-        {
-          using std::min;
-          using std::max;
-          auto currentPose = arm.GetEffectorPose();
-          auto aboveCurrent = currentPose;
-          auto calculateZAboveTarget = [&](double targetZ) {
-            double constexpr MinimumZ = 0.3;
-            double constexpr MaximumZ = 0.4;
-            double constexpr ZOffset = 0.1;
+      if (!arm.MoveThroughWaypoints({request->target_pose.pose})) return;
 
-            return min(MaximumZ, max(targetZ + ZOffset, MinimumZ));
-          };
-          aboveCurrent[2] = calculateZAboveTarget(aboveCurrent[2]);
-          auto aboveTarget = request->target_pose.pose;
-
-          aboveTarget.position.z =
-              calculateZAboveTarget(aboveTarget.position.z);
-          if (!arm.MoveThroughWaypoints(
-                  {arm.CalculatePose(aboveCurrent[0], aboveCurrent[1],
-                                     aboveCurrent[2]),
-                   aboveTarget, request->target_pose.pose}))
-            return;
-
-          if (request->final_gripper_state) {
-            arm.Open();
-          } else {
-            arm.Close();
-          }
-        }
-
-        if (!arm.MoveThroughWaypoints({request->target_pose.pose}))
-          return;
-
-        response->success = true;
-      });
+      response->success = true;
+    });
 
   RCLCPP_INFO(logger, "Service /manipulator_move_to is ready");
 
   m_resetService = m_node->create_service<std_srvs::srv::Trigger>(
-      "/reset_manipulator",
-      [&]([[maybe_unused]] std::shared_ptr<
-              std_srvs::srv::Trigger::Request> const request,
-          std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-        RCLCPP_INFO(logger, "Received reset request");
-        response->success = arm.SetJointValues(m_startingPose);
-      });
+    "/reset_manipulator",
+    [&](
+      [[maybe_unused]] std::shared_ptr<std_srvs::srv::Trigger::Request> const request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+      RCLCPP_INFO(logger, "Received reset request");
+      response->success = arm.SetJointValues(m_startingPose);
+    });
 }
 
-void RaiManipulationInterfaceNode::Spin() {
+void RaiManipulationInterfaceNode::Spin()
+{
   m_executor.add_node(m_node);
   m_executor.spin();
 }

--- a/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
@@ -81,9 +81,9 @@ void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
           auto currentPose = arm.GetEffectorPose();
           auto aboveCurrent = currentPose;
           auto calculateZAboveTarget = [&](double targetZ) {
-            double const MinimumZ = 0.3;
-            double const MaximumZ = 0.4;
-            double const ZOffset = 0.1;
+            double constexpr MinimumZ = 0.3;
+            double constexpr MaximumZ = 0.4;
+            double constexpr ZOffset = 0.1;
 
             return min(MaximumZ, max(targetZ + ZOffset, MinimumZ));
           };

--- a/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/rai_manipulation_interface_node.cpp
@@ -16,23 +16,13 @@
 #include "robotic_manipulation/rai_manipulation_interface_node.h"
 
 #include <std_msgs/msg/float32_multi_array.hpp>
-#include <std_srvs/srv/trigger.hpp>
-
-#include "rai_interfaces/srv/manipulator_move_to.hpp"
 
 RaiManipulationInterfaceNode::RaiManipulationInterfaceNode()
     : m_node(rclcpp::Node::make_shared("state_controller")) {
   m_node->set_parameter(rclcpp::Parameter("use_sim_time", true));
 }
 
-RaiManipulationInterfaceNode::~RaiManipulationInterfaceNode() {
-  m_executor.cancel();
-  if (m_spinner.joinable()) {
-    m_spinner.join();
-  }
-}
-
-void RaiManipulationInterfaceNode::Begin(ArmController &arm) {
+void RaiManipulationInterfaceNode::Initialize(ArmController &arm) {
   auto logger = m_node->get_logger();
 
   auto current_pose = arm.GetEffectorPose();
@@ -48,7 +38,7 @@ void RaiManipulationInterfaceNode::Begin(ArmController &arm) {
               current_z, current_rx, current_ry, current_rz);
   RCLCPP_INFO(logger, "Current gripper state: %d", current_gripper_state);
 
-  auto service = m_node->create_service<rai_interfaces::srv::ManipulatorMoveTo>(
+  m_moveToService = m_node->create_service<rai_interfaces::srv::ManipulatorMoveTo>(
       "/manipulator_move_to",
       [&](std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Request> const
               request,
@@ -116,7 +106,7 @@ void RaiManipulationInterfaceNode::Begin(ArmController &arm) {
 
   RCLCPP_INFO(logger, "Service /manipulator_move_to is ready");
 
-  auto reset_service = m_node->create_service<std_srvs::srv::Trigger>(
+  m_resetService = m_node->create_service<std_srvs::srv::Trigger>(
       "/reset_manipulator",
       [&]([[maybe_unused]] std::shared_ptr<
               std_srvs::srv::Trigger::Request> const request,
@@ -124,8 +114,9 @@ void RaiManipulationInterfaceNode::Begin(ArmController &arm) {
         RCLCPP_INFO(logger, "Received reset request");
         response->success = arm.SetJointValues(m_startingPose);
       });
+}
 
-  // Add node to executor and spin in the main thread
+void RaiManipulationInterfaceNode::Spin() {
   m_executor.add_node(m_node);
   m_executor.spin();
 }

--- a/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
@@ -19,19 +19,20 @@
 #include "robotic_manipulation/arm_controller.h"
 #include "robotic_manipulation/rai_manipulation_interface_node.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char * argv[])
+{
   // Initialize ROS and create the Node
   rclcpp::init(argc, argv);
 
   auto armController = std::make_shared<ArmController>();
   armController->Initialize();
 
-  constexpr double EndEffectorBaseX = 0.3;
-  constexpr double EndEffectorBaseY = 0.0;
-  constexpr double EndEffectorBaseZ = 0.35;
+  double constexpr EndEffectorBaseX = 0.3;
+  double constexpr EndEffectorBaseY = 0.0;
+  double constexpr EndEffectorBaseZ = 0.35;
 
-  armController->MoveThroughWaypoints({armController->CalculatePose(
-      EndEffectorBaseX, EndEffectorBaseY, EndEffectorBaseZ)});
+  armController->MoveThroughWaypoints(
+    {armController->CalculatePose(EndEffectorBaseX, EndEffectorBaseY, EndEffectorBaseZ)});
 
   std::vector<double> startingPose;
   startingPose = armController->CaptureJointValues();

--- a/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
@@ -1,9 +1,8 @@
 #include <memory>
+#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include "robotic_manipulation/arm_controller.h"
 #include "robotic_manipulation/state_controller.h"
-
-#include <std_msgs/msg/float32_multi_array.hpp>
 
 int main(int argc, char *argv[]) {
   // Initialize ROS and create the Node
@@ -12,7 +11,8 @@ int main(int argc, char *argv[]) {
   auto armController = std::make_shared<ArmController>();
   armController->Initialize();
 
-  armController->MoveThroughWaypoints({armController->CalculatePose(0.3, 0.0, 0.35)});
+  armController->MoveThroughWaypoints(
+      {armController->CalculatePose(0.3, 0.0, 0.35)});
 
   std::vector<double> startingPose;
   startingPose = armController->CaptureJointValues();

--- a/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
@@ -1,3 +1,18 @@
+/* Copyright (C) 2025 Robotec.AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <memory>
 #include <std_msgs/msg/float32_multi_array.hpp>
 

--- a/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
@@ -26,8 +26,12 @@ int main(int argc, char *argv[]) {
   auto armController = std::make_shared<ArmController>();
   armController->Initialize();
 
-  armController->MoveThroughWaypoints(
-      {armController->CalculatePose(0.3, 0.0, 0.35)});
+  constexpr double EndEffectorBaseX = 0.3;
+  constexpr double EndEffectorBaseY = 0.0;
+  constexpr double EndEffectorBaseZ = 0.35;
+
+  armController->MoveThroughWaypoints({armController->CalculatePose(
+      EndEffectorBaseX, EndEffectorBaseY, EndEffectorBaseZ)});
 
   std::vector<double> startingPose;
   startingPose = armController->CaptureJointValues();

--- a/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/robotic_manipulation.cpp
@@ -17,7 +17,7 @@
 #include <std_msgs/msg/float32_multi_array.hpp>
 
 #include "robotic_manipulation/arm_controller.h"
-#include "robotic_manipulation/state_controller.h"
+#include "robotic_manipulation/rai_manipulation_interface_node.h"
 
 int main(int argc, char *argv[]) {
   // Initialize ROS and create the Node
@@ -35,8 +35,11 @@ int main(int argc, char *argv[]) {
   armController->SetJointValues(startingPose);
   armController->Close();
 
-  StateController state;
-  state.Begin(*armController);
+  {
+    RaiManipulationInterfaceNode raiInterface;
+    raiInterface.Initialize(*armController);
+    raiInterface.Spin();
+  }
 
   armController->SetJointValues(startingPose);
 

--- a/ros2_ws/src/robotic_manipulation/src/state_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/state_controller.cpp
@@ -1,3 +1,18 @@
+/* Copyright (C) 2025 Robotec.AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "robotic_manipulation/state_controller.h"
 
 #include <std_msgs/msg/float32_multi_array.hpp>

--- a/ros2_ws/src/robotic_manipulation/src/state_controller.cpp
+++ b/ros2_ws/src/robotic_manipulation/src/state_controller.cpp
@@ -2,11 +2,11 @@
 
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_srvs/srv/trigger.hpp>
+
 #include "rai_interfaces/srv/manipulator_move_to.hpp"
 
-StateController::StateController() 
-  : m_node(rclcpp::Node::make_shared("state_controller"))
-{
+StateController::StateController()
+    : m_node(rclcpp::Node::make_shared("state_controller")) {
   m_node->set_parameter(rclcpp::Parameter("use_sim_time", true));
 }
 
@@ -34,77 +34,81 @@ void StateController::Begin(ArmController &arm) {
   RCLCPP_INFO(logger, "Current gripper state: %d", current_gripper_state);
 
   auto service = m_node->create_service<rai_interfaces::srv::ManipulatorMoveTo>(
-    "/manipulator_move_to",
-    [&](const std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Request> request,
-        std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Response> response) {
-      RCLCPP_INFO(logger, "Received move request");
+      "/manipulator_move_to",
+      [&](std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Request> const
+              request,
+          std::shared_ptr<rai_interfaces::srv::ManipulatorMoveTo::Response>
+              response) {
+        RCLCPP_INFO(logger, "Received move request");
 
-      response->success = false;
+        response->success = false;
 
-      arm.SetReferenceFrame(request->target_pose.header.frame_id);
-      RCLCPP_INFO(logger, "Set reference frame to: %s", request->target_pose.header.frame_id.c_str());
+        arm.SetReferenceFrame(request->target_pose.header.frame_id);
+        RCLCPP_INFO(logger, "Set reference frame to: %s",
+                    request->target_pose.header.frame_id.c_str());
 
-      // Print current pose
-      auto current_pose = arm.GetEffectorPose();
-      auto [current_x, current_y, current_z, current_rx, current_ry, current_rz] =
-          std::make_tuple(current_pose[0], current_pose[1], current_pose[2],
-                          current_pose[3], current_pose[4], current_pose[5]);
-
-      RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", current_x, current_y,
-                  current_z, current_rx, current_ry, current_rz);
-      RCLCPP_INFO(logger, "Target pose: %f %f %f %f %f %f", 
-                  request->target_pose.pose.position.x, 
-                  request->target_pose.pose.position.y, 
-                  request->target_pose.pose.position.z,
-                  request->target_pose.pose.orientation.x,
-                  request->target_pose.pose.orientation.y,
-                  request->target_pose.pose.orientation.z);
-
-      if (request->initial_gripper_state) {
-        arm.Open();
-      } else {
-        arm.Close();
-      }
-
-      {
-        using std::min;
-        using std::max;
+        // Print current pose
         auto current_pose = arm.GetEffectorPose();
-        auto above_current = current_pose;
-        above_current[2] = min(0.4, max(above_current[2] + 0.1, 0.3));
-        auto above_target = request->target_pose.pose;
+        auto [current_x, current_y, current_z, current_rx, current_ry,
+              current_rz] =
+            std::make_tuple(current_pose[0], current_pose[1], current_pose[2],
+                            current_pose[3], current_pose[4], current_pose[5]);
 
-        above_target.position.z = min(0.4, max(above_target.position.z + 0.1, 0.3));
-        if (!arm.MoveThroughWaypoints(
-                {arm.CalculatePose(above_current[0], above_current[1],
-                                   above_current[2]),
-                 above_target, request->target_pose.pose}))
-          return;
+        RCLCPP_INFO(logger, "Current pose: %f %f %f %f %f %f", current_x,
+                    current_y, current_z, current_rx, current_ry, current_rz);
+        RCLCPP_INFO(logger, "Target pose: %f %f %f %f %f %f",
+                    request->target_pose.pose.position.x,
+                    request->target_pose.pose.position.y,
+                    request->target_pose.pose.position.z,
+                    request->target_pose.pose.orientation.x,
+                    request->target_pose.pose.orientation.y,
+                    request->target_pose.pose.orientation.z);
 
-        if (request->final_gripper_state) {
+        if (request->initial_gripper_state) {
           arm.Open();
         } else {
           arm.Close();
         }
-      }
 
-      if (!arm.MoveThroughWaypoints({request->target_pose.pose}))
-        return;
+        {
+          using std::min;
+          using std::max;
+          auto current_pose = arm.GetEffectorPose();
+          auto above_current = current_pose;
+          above_current[2] = min(0.4, max(above_current[2] + 0.1, 0.3));
+          auto above_target = request->target_pose.pose;
 
-      response->success = true;
-    }
-  );
+          above_target.position.z =
+              min(0.4, max(above_target.position.z + 0.1, 0.3));
+          if (!arm.MoveThroughWaypoints(
+                  {arm.CalculatePose(above_current[0], above_current[1],
+                                     above_current[2]),
+                   above_target, request->target_pose.pose}))
+            return;
+
+          if (request->final_gripper_state) {
+            arm.Open();
+          } else {
+            arm.Close();
+          }
+        }
+
+        if (!arm.MoveThroughWaypoints({request->target_pose.pose}))
+          return;
+
+        response->success = true;
+      });
 
   RCLCPP_INFO(logger, "Service /manipulator_move_to is ready");
 
   auto reset_service = m_node->create_service<std_srvs::srv::Trigger>(
-    "/reset_manipulator",
-    [&]([[maybe_unused]] const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-      RCLCPP_INFO(logger, "Received reset request");
-      response->success = arm.SetJointValues(m_startingPose);
-    }
-  );
+      "/reset_manipulator",
+      [&]([[maybe_unused]] std::shared_ptr<
+              std_srvs::srv::Trigger::Request> const request,
+          std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+        RCLCPP_INFO(logger, "Received reset request");
+        response->success = arm.SetJointValues(m_startingPose);
+      });
 
   // Add node to executor and spin in the main thread
   m_executor.add_node(m_node);


### PR DESCRIPTION
This PR refactors the robotic manipulation package to improve the quality of the code. In particular, this PR:

- Decouples service initialization code with node spinning code
- Renames the `StateController` class to better mirror its purpose
- Replaces magic values with constants
- Formats all the files using clang-format
- Adds a license note to every source code file
- Fills the package description and license information in `package.xml`